### PR TITLE
Add Schematron Validation

### DIFF
--- a/gdtf.sch
+++ b/gdtf.sch
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sch:schema
+        xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+        xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+    <sch:title>GDTF 1.1 (DIN 15800:2020-07)</sch:title>
+    <sch:p>These assertions fill validation holes in the main XSD Schema for GDTF 1.1.</sch:p>
+
+    <!-- Keys -->
+    <xsl:key
+            name="featureKey"
+            match="//GDTF/FixtureType/AttributeDefinitions/FeatureGroups/FeatureGroup/Feature"
+            use="concat(../@Name, '.', @Name)" />
+
+    <!-- Patterns -->
+    <sch:pattern name="Occurence Constraints">
+        <sch:rule context="//GDTF/FixtureType/PhysicalDescriptions/Properties">
+            <sch:assert test="count(OperatingTemperature) le 1">Error: More than one OperatingTemperature node.</sch:assert>
+            <sch:assert test="count(Weight) le 1">Error: More than one Weight node.</sch:assert>
+            <sch:assert test="count(LegHeight) le 1">Error: More than 1 LegHeight node.</sch:assert>
+        </sch:rule>
+    </sch:pattern>
+
+    <sch:pattern name="Feature References">
+        <sch:rule context="//GDTF/FixtureType/AttributeDefinitions/Attributes/Attribute">
+            <sch:assert test="key('featureKey', @Feature)">Error: Attribute Node with Name "<xsl:value-of 
+            select="@Name" />" references Feature "<xsl:value-of select="@Feature" />" which does not exist.</sch:assert>
+        </sch:rule>
+    </sch:pattern>
+
+    <sch:pattern name="ModeMaster Reference">
+        <sch:rule context="//GDTF/FixtureType/DMXModes/DMXMode/DMXChannels/DMXChannel/LogicalChannel/ChannelFunction/@ModeMaster">
+            <!-- This test tries to find the node referenced by ModeMaster. 
+            Either a DMXChannel in the same mode (first line) or a ChannelFunction (second line) in the same mode. -->
+
+            <!-- TODO: The default name of ChannelFunction needs to be considered here:
+            Default value: Name of attribute and number of channel function. 
+            TODO: clarify the meaning of the above sentence in the standard
+            Is the number the number of all channelFuntions or just the number within the channelFunctions with this specific
+            Attribute? So:
+
+            Dimmer1
+            Pan2
+            Pan3
+
+            OR
+
+            Dimmer1
+            Pan1
+            Pan2-->
+            <sch:assert test="
+            ../../../../DMXChannel[concat(@Geometry, '_', LogicalChannel[1]/@Attribute) eq current()]
+            |
+            ../../../../DMXChannel/LogicalChannel/ChannelFunction
+            [concat(../../@Geometry, '_', ../../LogicalChannel[1]/@Attribute, '.', ../@Attribute, '.', @Name) eq current()]
+            ">Error: ChannelFunction "<xsl:value-of select="
+                concat(../../../@Geometry, '_', ../../../LogicalChannel[1]/@Attribute, '.', ../../@Attribute, '.', ../@Name)
+                " />" in DMXMode "<xsl:value-of select="../../../../../@Name" />" references ModeMaster "<xsl:value-of 
+                select="." />" which does not exist in this mode.
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+
+    <sch:pattern name="Unique DMXChannel Name in each DMXMode">
+        <sch:rule context="//GDTF/FixtureType/DMXModes/DMXMode/DMXChannels">
+            <sch:assert test="
+            count(DMXChannel) eq count(distinct-values(DMXChannel/concat(@Geometry, '_', LogicalChannel[1]/@Attribute)))
+            ">Error: The DMXMode "<xsl:value-of select="../@Name"
+             />" contains multiple DMXChannel nodes with the same name(s) <xsl:for-each select="
+                let $seq := DMXChannel/concat(@Geometry, '_', LogicalChannel[1]/@Attribute)
+                return $seq[index-of($seq,.)[2]]
+                ">"<xsl:value-of select="." />" </xsl:for-each>
+            </sch:assert>
+        </sch:rule>
+    </sch:pattern>
+
+    <sch:pattern name="Unique combination of Attribute and Geometry for each LogicalChannel in a given DMXMode">
+        <!-- TODO: reports twice for each duplicate. Would be nicer if it reported once per duplication. -->
+        <sch:rule context="//GDTF/FixtureType/DMXModes/DMXMode/DMXChannels/DMXChannel/LogicalChannel">
+            <sch:assert test="count(../../DMXChannel/LogicalChannel[@Attribute eq current()/@Attribute and ../@Geometry eq current()/../@Geometry]) eq 1
+            ">Error: The DMXMode "<xsl:value-of select="../../../@Name" 
+                />" contains multiple LogicalChannels with the Attribute "<xsl:value-of 
+                select="@Attribute" />" and the Geometry "<xsl:value-of select="../@Geometry" />".</sch:assert>
+        </sch:rule>
+    </sch:pattern>
+
+</sch:schema>

--- a/gdtf.sch
+++ b/gdtf.sch
@@ -30,29 +30,18 @@
 
     <sch:pattern name="ModeMaster Reference">
         <sch:rule context="//GDTF/FixtureType/DMXModes/DMXMode/DMXChannels/DMXChannel/LogicalChannel/ChannelFunction/@ModeMaster">
-            <!-- This test tries to find the node referenced by ModeMaster. 
-            Either a DMXChannel in the same mode (first line) or a ChannelFunction (second line) in the same mode. -->
-
-            <!-- TODO: The default name of ChannelFunction needs to be considered here:
-            Default value: Name of attribute and number of channel function. 
-            TODO: clarify the meaning of the above sentence in the standard
-            Is the number the number of all channelFuntions or just the number within the channelFunctions with this specific
-            Attribute? So:
-
-            Dimmer1
-            Pan2
-            Pan3
-
-            OR
-
-            Dimmer1
-            Pan1
-            Pan2-->
+            <!-- This test tries to find the node referenced by ModeMaster, 
+            either a DMXChannel or a ChannelFunction in the same mode. -->
             <sch:assert test="
             ../../../../DMXChannel[concat(@Geometry, '_', LogicalChannel[1]/@Attribute) eq current()]
             |
             ../../../../DMXChannel/LogicalChannel/ChannelFunction
-            [concat(../../@Geometry, '_', ../../LogicalChannel[1]/@Attribute, '.', ../@Attribute, '.', @Name) eq current()]
+            [
+                let $channelFunctionName := if(not(@Name)) then(concat(@Attribute, ' ', position())) else(@Name)
+                return concat(
+                    ../../@Geometry, '_', ../../LogicalChannel[1]/@Attribute, '.', ../@Attribute, '.', $channelFunctionName
+                ) eq current()
+            ]
             ">Error: ChannelFunction "<xsl:value-of select="
                 concat(../../../@Geometry, '_', ../../../LogicalChannel[1]/@Attribute, '.', ../../@Attribute, '.', ../@Name)
                 " />" in DMXMode "<xsl:value-of select="../../../../../@Name" />" references ModeMaster "<xsl:value-of 
@@ -77,7 +66,9 @@
     <sch:pattern name="Unique combination of Attribute and Geometry for each LogicalChannel in a given DMXMode">
         <!-- TODO: reports twice for each duplicate. Would be nicer if it reported once per duplication. -->
         <sch:rule context="//GDTF/FixtureType/DMXModes/DMXMode/DMXChannels/DMXChannel/LogicalChannel">
-            <sch:assert test="count(../../DMXChannel/LogicalChannel[@Attribute eq current()/@Attribute and ../@Geometry eq current()/../@Geometry]) eq 1
+            <sch:assert test="count(
+                ../../DMXChannel/LogicalChannel[@Attribute eq current()/@Attribute and ../@Geometry eq current()/../@Geometry]
+                ) eq 1
             ">Error: The DMXMode "<xsl:value-of select="../../../@Name" 
                 />" contains multiple LogicalChannels with the Attribute "<xsl:value-of 
                 select="@Attribute" />" and the Geometry "<xsl:value-of select="../@Geometry" />".</sch:assert>

--- a/gdtf.sch
+++ b/gdtf.sch
@@ -75,4 +75,19 @@
         </sch:rule>
     </sch:pattern>
 
+    <sch:pattern name="No Conflict between Default ChannelFunction Name and other ChannelFunction Names in a given LogicalChannel">
+        <sch:rule context="//GDTF/FixtureType/DMXModes/DMXMode/DMXChannels/DMXChannel/LogicalChannel/ChannelFunction[not(@Name)]">
+            <sch:assert test="
+                let $defaultChannelFunctionName := concat(@Attribute, ' ', count(preceding-sibling::ChannelFunction)+1)
+                return count(../ChannelFunction[@Name eq $defaultChannelFunctionName]) eq 0
+            ">Error: In DMX Mode "<xsl:value-of select="../../../../@Name"/>", the Name of Channel Function "<xsl:value-of 
+            select="concat(
+                ../../@Geometry, '_', ../../LogicalChannel[1]/@Attribute, '.', ../@Attribute, '.', concat(@Attribute, ' ', 
+                count(preceding-sibling::ChannelFunction)+1)
+            )"/>" conincides with the default Name of Channel Function Number <xsl:value-of select="
+            count(preceding-sibling::ChannelFunction)+1" /> in the Logical Channel "<xsl:value-of select="
+            concat(../../@Geometry, '_', ../../LogicalChannel[1]/@Attribute, '.', ../@Attribute)"/>".</sch:assert>
+        </sch:rule>
+    </sch:pattern>
+
 </sch:schema>

--- a/gdtf.xsd
+++ b/gdtf.xsd
@@ -455,13 +455,7 @@
   </xs:complexType>
   <xs:complexType name="DMXMode">
     <xs:sequence>
-      <xs:element name="DMXChannels" type="DMXChannels">
-        <xs:unique name="UniqueCombinationOfGeometryAndAttributeForLogicalChannel">
-          <xs:selector xpath="DMXChannel"/>
-          <xs:field xpath="@Geometry"/>
-          <xs:field xpath="LogicalChannel/@Attribute"/>
-        </xs:unique>
-      </xs:element>
+      <xs:element name="DMXChannels" type="DMXChannels"/>
       <xs:element name="Relations" type="Relations" minOccurs="0" maxOccurs="1">
         <xs:unique name="UniqueRelationName">
           <xs:selector xpath="Relation"/>


### PR DESCRIPTION
Hey, 

I recently reworked the XML Schema to provide support for DIN 15800:2020-07 (GDTF 1.1). Due to the restricted expressiveness of XSD 1.0, there were some validation gaps left in the Schema that I wanted to fill. This can be done with an assertion-based schema language like [Schematron](https://schematron.com/). I added a Schematron file called `gdtf.sch`. It can be used to validate instance files with different tools, I used the [schXslt](https://github.com/schxslt/schxslt) Java CLI for development. 

I downloaded all GDTF 1.1 files from GDTF Share on January 27 2021 20:00. All of those XML files pass the Schematron validation proposed here. 

Included validations:
- Restricted Occurence for some children of PhysicalDescriptions/Properties
- Validate Feature Reference in Attribute Definition
- Validate ModeMaster Reference in ChannelFunction
- Unique DMXChannel name
- Unique LogicalChannel

# Remaining Questions to the Maintainer(s)

- How is the default name of the ChannelFunction constructed? Like this:
```
Dimmer1
Pan2
Pan3
```
or like this:
```
Dimmer1
Pan1
Pan2
```
- What does "All logical channels that are children of the same DMX channel are exclusive. " (DIN 15800:2020-07, page 33) mean?
- How is it ensured that in a given DMXMode, no two ChannelFunctions controlling the same Attribute of the same Geometry are active at the same time, therefore providing potentially two different values for the same Attribute?

