### PR TITLE
Allow Empty String for DmxChannel Offset

### DIFF
--- a/gdtf.xsd
+++ b/gdtf.xsd
@@ -672,7 +672,7 @@
   </xs:simpleType>
   <xs:simpleType name="offsettype">
     <xs:restriction base="xs:string">
-      <xs:pattern value="None|([0-9]+(,[0-9]+)*)"/>
+      <xs:pattern value="None|([0-9]*(,[0-9]+)*)"/>
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="dmxtype">


### PR DESCRIPTION
closes #71 

Before merging, this should go on the list of things that need to be clarified in the GDTF spec. Something like: 

> Empty string represents an empty array. It has the same meaning as "None".

and proper examples should be included. 