### PR TITLE
Clarify Channel Function Default Name

### DIFF
--- a/gdtf-spec.md
+++ b/gdtf-spec.md
@@ -1919,7 +1919,7 @@ currently defined XML attributes of channel function are specified in
 
 | XML Attribute Name | Value Type                                   | Description                                                                                                                                                   |
 |----|----|----|
-| Name               | [Name](#user-content-attrtype-name )         | Unique name; Default value: Name of attribute and number of channel function.                                                                                 |
+| Name               | [Name](#user-content-attrtype-name )         | Unique name; Default value: Name of Attribute and 1-based index of Channel Function inside the Logical Channel, separated by a space; Example: "Dimmer 1".                                                                                 |
 | Attribute          | [Node](#user-content-attrtype-node )         | Link to attribute; Starting point is the attributes node. Default value: “NoFeature”.                                                                         |
 | OriginalAttribute  | [String](#user-content-attrtype-string )     | The manufacturer's original name of the attribute; Default: empty                                                                                             |
 | DMXFrom            | [DMXValue](#user-content-attrtype-dmxvalue ) | Start DMX value; The end DMX value is calculated as a DMXFrom of the next channel function – 1 or the maximum value of the DMX channel. Default value: "0/1". |


### PR DESCRIPTION
[…n inside the Logical Channel, separated by a space; Example: "Dimmer 1".](https://github.com/mvrdevelopment/spec/issues/75)

@ Firionus