### PR TITLE
removed power consumption node

### DIFF
--- a/gdtf-spec.md
+++ b/gdtf-spec.md
@@ -967,7 +967,6 @@ are specified in [table 28](#user-content-table-28 ).
 |----|----|----|
 | [OperatingTemperature](#user-content-operatingtemperature ) | 0 or 1 | Temperature range in which the device can be operated. |
 | [Weight](#user-content-weight )                             | 0 or 1 | Weight of the device including all accessories.        |
-| [PowerConsumption](#user-content-powerconsumption )         | Any    | Power information for a given connector.               |
 | [LegHeight](#user-content-legheight )                       | 0 or 1 | Height of the legs.                                    |
 
 


### PR DESCRIPTION
from properties collect. This was already obsoleted with DIN Spec 15800:2022:02 and is removed now. It was replaced by the wiring object geometry type.
This fixes #220 