### PR TITLE
Fix typo in CustomName description

### DIFF
--- a/gdtf-spec.md
+++ b/gdtf-spec.md
@@ -1933,7 +1933,7 @@ currently defined XML attributes of channel function are specified in
 | DMXProfile         | [Node](#user-content-attrtype-node )         | Optional link to DMX Profile; Starting point: DMX Profile Collect                                                                                             |
 | Min                | [Float](#user-content-attrtype-float )       | Minimum Physical Value that will be used for the DMX Profile. Default: Value from PhysicalFrom                                                                |
 | Max                | [Float](#user-content-attrtype-float )       | Maximum Physical Value that will be used for the DMX Profile. Default: Value from PhysicalTo                                                                  |
-| CustomName         | [String](#user-content-attrtype-string )     | Custom Name that can he used do adress this channel function with other command based protocols like OSC. Default: Node Name of the Channel function Example: Head_Dimmer.Dimmer.Dimmer   |
+| CustomName         | [String](#user-content-attrtype-string )     | Custom Name that can be used to adress this channel function with other command based protocols like OSC. Default: Node Name of the Channel function Example: Head_Dimmer.Dimmer.Dimmer   |
 
 
 


### PR DESCRIPTION
Like it says in the title - this is a fix for a small typo